### PR TITLE
Fix a crash alongside other plugins

### DIFF
--- a/android/src/main/kotlin/com/actionsprout/facebook/FacebookPlugin.kt
+++ b/android/src/main/kotlin/com/actionsprout/facebook/FacebookPlugin.kt
@@ -103,7 +103,7 @@ public class FacebookPlugin : ActivityAware, ActivityResultListener, FlutterPlug
         }
     }
 
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent): Boolean {
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean {
         return callbackManager.onActivityResult(requestCode, resultCode, data)
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: facebook
 description: Flutter integration to first-party Facebook SDKs.
-version: 1.0.0
+version: 1.0.1
 author:
 homepage:
 


### PR DESCRIPTION
It looks like this issue only surfaced on Android, and when installed alongside other plugins that expect `data` to be `null` under certain circumstances (e.g. when cancelling the image picker).

The previous version got compiled to byte code that forbid that being passed into our own `onActivityResult`, though we're passing it on to a callback manager that does the routing and filtering for us.

Either way, that crash should no longer occur.

Bumped version to v1.0.1 as a result of the patch.